### PR TITLE
Wrong condition in key parsing

### DIFF
--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -53,7 +53,8 @@ var zabbix_host_key = function (key) {
     var host_key = key.split('.');
 
     // Handle a namespace in front of host.key
-    if (host_key.length === 3) {
+    // Cyprien DIOT edit: Must be >= to handle dots in keys
+    if (host_key.length >= 3) {
       var namespace = host_key[0];
       var host = host_key[1];
       var key = host_key[2];


### PR DESCRIPTION
I was unable to use this statsd plugin with keys like: logstash.host.my.zbx.key because of a condition in the key parsing.
I fixed it for my own needs

Thanks for your work ! :-)
