### PR TITLE
introduce configurable hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ All Zabbix items are expected to be type "Zabbix trapper" to support receiving d
 
 Send your host:key separated by an underscore, for example: `host.example.com_my.key:1|c`
 
-See Logstash examples for specific keys Zabbix will receive based on metric type.
+Alternatively, configure statsd with `hostname` in order to set a static
+hostname to be sent to zabbix. For example, you may run statsd on each
+zabbix monitored host and configure statsd-zabbix-backend to always send the
+hostname of the current host. This is useful for sources other than logstash
+which do not encode the hostname in the statsd key.
 
 ### Logstash
 
@@ -43,6 +47,8 @@ Logstash's statsd output sends data in the format namespace.sender.metric.
 - namespace: default is "logstash"
 - sender: default is "%{host}", replacing dots with underscores
 - metric: name of the metric used in increment
+
+See Logstash examples for specific keys Zabbix will receive based on metric type.
 
 #### Counters
 

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -12,6 +12,11 @@
  *   zabbixPort: Port to contact zabbix server at.
  *   zabbixSender: Path to zabbix_sender utility.
  *
+ *   Optional
+ *   hostname: Static hostname associated with the stats to send to zabbix
+ *             If provided, StatsD Zabbix backend will not attempt to decode a 
+ *             hostname from each key
+ *
  */
 
 var util = require('util'),
@@ -49,7 +54,7 @@ var post_stats = function zabbix_post_stats(statString) {
   }
 }
 
-var zabbix_host_key = function (key) {
+var zabbix_host_key_from_encoding = function (key) {
     // Logstash uses a . separator, but what is standard?
     var host_key = key.split('.');
 
@@ -85,7 +90,14 @@ var zabbix_host_key = function (key) {
     }
 }
 
-var flush_stats = function zabbix_flush(ts, metrics) {
+var zabbix_host_key_from_config = function (host, key) {
+    return {
+        'host': host,
+        'key': key
+    };
+}
+
+var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
   var statString = '';
   var numStats = 0;
   var key;
@@ -172,13 +184,15 @@ var backend_status = function zabbix_status(writeCb) {
   }
 };
 
-exports.zabbix_host_key = zabbix_host_key;
+exports.zabbix_host_key_from_encoding = zabbix_host_key_from_encoding;
+exports.zabbix_host_key_from_config = zabbix_host_key_from_config;
 
 exports.init = function zabbix_init(startup_time, config, events) {
   debug = config.debug;
   zabbixHost = config.zabbixHost;
   zabbixPort = config.zabbixPort;
   zabbixSender = config.zabbixSender;
+  zabbix_host_key = config.hostname ? zabbix_host_key_from_config.bind(undefined, config.hostname) : zabbix_host_key_from_encoding;
   zabbixCmd = zabbixSender + ' -T -i - -z ' + zabbixHost + ' -p ' + zabbixPort;
 
   zabbixStats.last_flush = startup_time;
@@ -186,8 +200,9 @@ exports.init = function zabbix_init(startup_time, config, events) {
 
   flushInterval = config.flushInterval;
 
-  events.on('flush', flush_stats);
+  events.on('flush', flush_stats.bind(undefined, zabbix_host_key));
   events.on('status', backend_status);
 
   return true;
 };
+

--- a/test/test-zabbix.js
+++ b/test/test-zabbix.js
@@ -3,20 +3,20 @@ var test = require('unit.js'),
 
 describe('Test key parsing', function() {
     it('longer key', function(){
-        var obj = zabbix.zabbix_host_key("namespace.host.first.second_1.third");
+        var obj = zabbix.zabbix_host_key_from_encoding("namespace.host.first.second_1.third");
 
         test.assert(obj.host == "host");
         test.assert(obj.key == "first_second_1_third");});
 
     it('some normal key', function() {
-        var obj = zabbix.zabbix_host_key("namespace.host.first");
+        var obj = zabbix.zabbix_host_key_from_encoding("namespace.host.first");
 
         test.assert(obj.host == "host");
         test.assert(obj.key == "first");
     });
 
     it('some normal key with _', function() {
-        var obj = zabbix.zabbix_host_key("namespace.host.first_second");
+        var obj = zabbix.zabbix_host_key_from_encoding("namespace.host.first_second");
 
         test.assert(obj.host == "host");
         test.assert(obj.key == "first_second");
@@ -24,14 +24,14 @@ describe('Test key parsing', function() {
 
 
     it('some logstash key', function() {
-        var obj = zabbix.zabbix_host_key("logstash.host_1.first_second");
+        var obj = zabbix.zabbix_host_key_from_encoding("logstash.host_1.first_second");
 
         test.assert(obj.host == "host.1");
         test.assert(obj.key == "first.second");
     });
 
     it('some kamon key', function() {
-        var obj = zabbix.zabbix_host_key("kamon.host_1.first_second");
+        var obj = zabbix.zabbix_host_key_from_encoding("kamon.host_1.first_second");
 
         test.assert(obj.host == "host.1");
         test.assert(obj.key == "first_second");
@@ -39,11 +39,21 @@ describe('Test key parsing', function() {
 
 
     it('some logstash key with no logstash namespace', function() {
-        var obj = zabbix.zabbix_host_key("blabla.host_1.first_second");
+        var obj = zabbix.zabbix_host_key_from_encoding("blabla.host_1.first_second");
 
         test.assert(obj.host == "host_1");
         test.assert(obj.key == "first_second");
     });
 
 
+});
+
+
+describe('Test key from configuration', function() {
+    it('returns hostname from configuration then key', function() {
+        var obj = zabbix.zabbix_host_key_from_config("host", "my.statsd.key");
+
+        test.assert(obj.host == "host");
+        test.assert(obj.key == "my.statsd.key");
+    });
 });


### PR DESCRIPTION
* users who do not wish to encode the hostname in the statsd key may
  configure statsd to use a static hostname when sending to zabbix
* useful for not-logstash flows i.e. statsd on each zabbix monitored
  host forwarding statsd metrics to zabbix