### PR TITLE
optionally use node-zabbix-sender instead of shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Overview
 
 This is a pluggable backend for [StatsD](https://github.com/etsy/statsd), which publishes stats to Zabbix.
+This fork adds the option of using the node-zabbix-sender module instead of a separate zabbix-sender binary.
 
 ## Installation
 
@@ -39,6 +40,7 @@ hostname to be sent to zabbix. For example, you may run statsd on each
 zabbix monitored host and configure statsd-zabbix-backend to always send the
 hostname of the current host. This is useful for sources other than logstash
 which do not encode the hostname in the statsd key.
+Leave zabbixSender config variable unset to use the node-zabbix-sender module.
 
 ### Logstash
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a pluggable backend for [StatsD](https://github.com/etsy/statsd), which 
   percentThreshold: [95, 99],
   backends: ["statsd-zabbix-backend"],
   zabbixPort: 10051,
-  zabbixHost: "localhost",
+  zabbixHost: "zabbix.example.com",
   zabbixTimestamps: true,
   hostname: "statsd.example.com"
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ## Overview
 
 This is a pluggable backend for [StatsD](https://github.com/etsy/statsd), which publishes stats to Zabbix.
-This fork adds the option of using the node-zabbix-sender module instead of a separate zabbix-sender binary.
 
 ## Installation
 
@@ -19,7 +18,8 @@ This fork adds the option of using the node-zabbix-sender module instead of a se
   backends: ["statsd-zabbix-backend"],
   zabbixPort: 10051,
   zabbixHost: "localhost",
-  zabbixSender: "/usr/bin/zabbix_sender"
+  zabbixTimestamps: true,
+  hostname: "statsd.example.com"
 }
 ```
 
@@ -40,7 +40,6 @@ hostname to be sent to zabbix. For example, you may run statsd on each
 zabbix monitored host and configure statsd-zabbix-backend to always send the
 hostname of the current host. This is useful for sources other than logstash
 which do not encode the hostname in the statsd key.
-Leave zabbixSender config variable unset to use the node-zabbix-sender module.
 
 ### Logstash
 

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -64,6 +64,7 @@ var post_stats = function zabbix_post_stats(statString) {
         var data = v.split(' ',4);
         // third one is always the timestamp so leave that out.
         Sender.addItem([data[0], data[1]].join('.'), data[3]);
+        console.log([data[0], data[1]].join('.'), data[3]);
       });
       Sender.send( function (err,res) {
         if (err) {

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -10,7 +10,7 @@
  *
  *   zabbixHost: Hostname of zabbix server.
  *   zabbixPort: Port to contact zabbix server at.
- *   zabbixSender: Path to zabbix_sender utility.
+ *   zabbixSender: Path to zabbix_sender utility. (leave blank to use node-zabbix-sender module instead)
  *
  *   Optional
  *   hostname: Static hostname associated with the stats to send to zabbix
@@ -26,30 +26,53 @@ var debug;
 var flushInterval;
 var zabbixHost;
 var zabbixPort;
-var zabbixSender;
+var zabbixCmd;
+var zabbixSender = null;
+var senderModule;
 
 var zabbixStats = {};
 
 var post_stats = function zabbix_post_stats(statString) {
   if (zabbixHost) {
     if (debug) {
-      util.log(statString);
+      util.log('statsString: ' + statString);
     }
 
-    try {
-      var zabbixExec = proc.exec(zabbixCmd, function(error, stdout, stderr) {
-        if (error && error.code !== 0 && debug) {
-          util.log(zabbixSender + ': ' + stderr);
-        }
-      });
+    if(zabbixCmd) {
+      try {
+        var zabbixExec = proc.exec(zabbixCmd, function (error, stdout, stderr) {
+          if (error && error.code !== 0 && debug) {
+            util.log(zabbixSender + ': ' + stderr);
+          }
+        });
 
-      zabbixExec.stdin.write(statString);
-      zabbixExec.stdin.end();
-    } catch(e) {
-      if (debug) {
-        util.log(e);
+        zabbixExec.stdin.write(statString);
+        zabbixExec.stdin.end();
+      } catch (e) {
+        if (debug) {
+          util.log(e);
+        }
+        zabbixStats.last_exception = Math.round(new Date().getTime() / 1000);
       }
-      zabbixStats.last_exception = Math.round(new Date().getTime() / 1000);
+    }
+    else {
+      // we're using the module, not a shell command
+      var Sender = new senderModule({host: zabbixHost, with_timestamps: true, items_host: 'test'});
+      // statString is a bunch of lines to be parsed and added one at a time.
+      var statArray = statString.split('\n');
+      statArray.forEach( function (v, i, array) {
+        var data = v.split(' ',4);
+        // third one is always the timestamp so leave that out.
+        Sender.addItem([data[0], data[1]].join('.'), data[3]);
+      });
+      Sender.send( function (err,res) {
+        if (err) {
+          throw err;
+        }
+
+        // print the response object - for testing
+        console.dir(res);
+      });
     }
   }
 }
@@ -98,6 +121,7 @@ var zabbix_host_key_from_config = function (host, key) {
 }
 
 var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
+  console.log('flushing stats...');
   var statString = '';
   var numStats = 0;
   var key;
@@ -193,7 +217,13 @@ exports.init = function zabbix_init(startup_time, config, events) {
   zabbixPort = config.zabbixPort;
   zabbixSender = config.zabbixSender;
   zabbix_host_key = config.hostname ? zabbix_host_key_from_config.bind(undefined, config.hostname) : zabbix_host_key_from_encoding;
-  zabbixCmd = zabbixSender + ' -T -i - -z ' + zabbixHost + ' -p ' + zabbixPort;
+
+  if(zabbixSender) {
+    zabbixCmd = zabbixSender + ' -T -i - -z ' + zabbixHost + ' -p ' + zabbixPort;
+  }
+  else {
+    senderModule = require('node-zabbix-sender');
+  }
 
   zabbixStats.last_flush = startup_time;
   zabbixStats.last_exception = startup_time;

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -39,6 +39,7 @@ var post_stats = function zabbix_post_stats(statString) {
     }
 
     if(zabbixCmd) {
+      // we're spawning a child process to run the shell zabbix_sender command
       try {
         var zabbixExec = proc.exec(zabbixCmd, function (error, stdout, stderr) {
           if (error && error.code !== 0 && debug) {
@@ -56,24 +57,34 @@ var post_stats = function zabbix_post_stats(statString) {
       }
     }
     else {
-      // we're using the module, not a shell command
-      var Sender = new senderModule({host: zabbixHost, with_timestamps: true, items_host: 'test'});
-      // statString is a bunch of lines to be parsed and added one at a time.
-      var statArray = statString.split('\n');
-      statArray.forEach( function (v, i, array) {
-        var data = v.split(' ',4);
-        // third one is always the timestamp so leave that out.
-        Sender.addItem([data[0], data[1]].join('.'), data[3]);
-        console.log([data[0], data[1]].join('.'), data[3]);
-      });
-      Sender.send( function (err,res) {
-        if (err) {
-          throw err;
-        }
+      // we're using the module, not a shell command, so no child process
+      try {
+        var Sender = new senderModule({host: zabbixHost, with_timestamps: true, items_host: '68.226.99.8'});
+        // statString is a bunch of lines to be parsed and added one at a time.
+        var statArray = statString.split('\n');
+        statArray.forEach(function (v, i, array) {
+          var data = v.split(' ', 4);
+          // third one is always the timestamp so leave that out.
+          Sender.addItem([data[0], data[1]].join('.'), data[3]);
+          if (debug) {
+            util.log([data[0], data[1]].join('.'), data[3]);
+          }
+        });
+        Sender.send(function (err, res) {
+          if (err) {
+            throw err;
+          }
 
-        // print the response object - for testing
-        console.dir(res);
-      });
+          // print the response object - for testing
+          if (debug) {
+            util.log(res);
+          }
+        });
+      } catch (e) {
+        if (debug) {
+          util.log('node-zabbix-sender error: ' + e);
+        }
+      }
     }
   }
 }

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -10,87 +10,29 @@
  *
  *   zabbixHost: Hostname of zabbix server.
  *   zabbixPort: Port to contact zabbix server at.
- *   zabbixSender: Path to zabbix_sender utility. (leave blank to use node-zabbix-sender module instead)
+ *   zabbixTimeout: true or false
  *
- *   Optional
- *   hostname: Static hostname associated with the stats to send to zabbix
- *             If provided, StatsD Zabbix backend will not attempt to decode a 
+ *   Optional option:
+ *   hostname: Static hostname/IP associated with the stats to send to zabbix
+ *             If not provided, StatsD Zabbix backend will  attempt to decode a
  *             hostname from each key
+ *             note that this must match the hostname in Zabbix, and remember
+ *             to "allow" that host in each Zabbix trap item that you're tracking.
  *
  */
 
 var util = require('util'),
     proc = require('child_process');
+var senderModule = require('node-zabbix-sender');
 
 var debug;
 var flushInterval;
 var zabbixHost;
 var zabbixPort;
-var zabbixCmd;
-var zabbixSender = null;
-var senderModule;
+var zabbixTimestamps;
+var zabbixSender;
 
 var zabbixStats = {};
-
-var post_stats = function zabbix_post_stats(statString) {
-  if (zabbixHost) {
-    if(zabbixCmd) {
-      // we're spawning a child process to run the shell zabbix_sender command
-      try {
-        var zabbixExec = proc.exec(zabbixCmd, function (error, stdout, stderr) {
-          if (error && error.code !== 0 && debug) {
-            util.log(zabbixSender + ': ' + stderr);
-          }
-        });
-
-        zabbixExec.stdin.write(statString);
-        zabbixExec.stdin.end();
-      } catch (e) {
-        if (debug) {
-          util.log(e);
-        }
-        zabbixStats.last_exception = Math.round(new Date().getTime() / 1000);
-      }
-    }
-    else {
-      // we're using the module, not a shell command, so no child process
-      try {
-        var Sender = new senderModule({host: zabbixHost, with_timestamps: true, items_host: '68.226.99.8'});
-        // statString is a bunch of lines to be parsed and added one at a time.
-        var statArray = statString.split('\n');
-        statArray.forEach(function (v, i, array) {
-          var data = v.split(' ', 4);
-          if (data[1]) {  // there might be a blank line at the end.
-            // third one is always the timestamp so leave that out.
-            Sender.addItem([data[0], data[1]].join('.'), data[3]);
-            if (debug) {
-              util.log([data[0], data[1]].join('.'), data[3]);
-            }
-          }
-        });
-
-
-        Sender.send(function (err, res) {
-          if (err) {
-            throw err;
-          }
-
-          // print the response object - for testing
-          if (debug) {
-            util.log(res);
-          }
-        });
-
-
-
-      } catch (e) {
-        if (debug) {
-          util.log('node-zabbix-sender error: ' + e);
-        }
-      }
-    }
-  }
-}
 
 var zabbix_host_key_from_encoding = function (key) {
     // Logstash uses a . separator, but what is standard?
@@ -135,8 +77,16 @@ var zabbix_host_key_from_config = function (host, key) {
     };
 }
 
+/**
+ * Periodically collate and send the data to zabbix
+ * @param zabbix_host_key
+ * @param ts - timestamp
+ * @param metrics
+ */
 var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
-  console.log('flushing stats...');
+  if (debug) {
+    util.log('flushing stats. ' + ts);  // TODO: do we need ts?
+  }
   var statString = '';
   var numStats = 0;
   var key;
@@ -147,14 +97,31 @@ var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
   var timers = metrics.timers;
   var pctThreshold = metrics.pctThreshold;
 
+  if (zabbixHost) {
+    // we're using only the module now, not a shell command
+    var senderConfig = {
+      host: zabbixHost,
+      port: zabbixPort,
+      with_timestamps: zabbixTimestamps
+    };
+  }
+  else {
+    throw('zabbixHost is required.');
+  }
+
+  var Sender = new senderModule(senderConfig);
+
+  // we don't need to construct the elaborate statString now that we're using the node-zabbix-sender module.
+  // we just add each item to the sender object.
   for (key in counters) {
     var value = counters[key];
     var valuePerSecond = value / (flushInterval / 1000); // calculate "per second" rate
 
     zabbix = zabbix_host_key(key);
 
-    statString += zabbix.host + ' ' + zabbix.key + '[total] ' + ts + ' ' + value          + "\n";
-    statString += zabbix.host + ' ' + zabbix.key + '[avg] '   + ts + ' ' + valuePerSecond + "\n";
+    // note that if with_timestamps is set, timestamps will be added to each item when sent.
+    Sender.addItem(zabbix.host, zabbix.key + '[total]', value);
+    Sender.addItem(zabbix.host, zabbix.key + '[avg]', valuePerSecond);
 
     numStats += 1;
   }
@@ -194,14 +161,13 @@ var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
 
         var clean_pct = '' + pct;
         clean_pct.replace('.', '_');
-        message += zabbix.host + ' ' + zabbix.key + '[mean]['  + clean_pct + '] ' + ts + ' ' + mean           + "\n";
-        message += zabbix.host + ' ' + zabbix.key + '[upper][' + clean_pct + '] ' + ts + ' ' + maxAtThreshold + "\n";
+        Sender.addItem(zabbix.host, zabbix.key + '[mean]['  + clean_pct + ']', mean);
+        Sender.addItem(zabbix.host, zabbix.key + '[upper][' + clean_pct + ']', maxAtThreshold);
       }
 
-      message += zabbix.host + ' ' + zabbix.key + '[upper] ' + ts + ' ' + max   + "\n";
-      message += zabbix.host + ' ' + zabbix.key + '[lower] ' + ts + ' ' + min   + "\n";
-      message += zabbix.host + ' ' + zabbix.key + '[count] ' + ts + ' ' + count + "\n";
-      statString += message;
+      Sender.addItem(zabbix.host, zabbix.key + '[upper]', max);
+      Sender.addItem(zabbix.host, zabbix.key + '[lower]', min);
+      Sender.addItem(zabbix.host, zabbix.key + '[count]', count);
 
       numStats += 1;
     }
@@ -210,11 +176,25 @@ var flush_stats = function zabbix_flush(zabbix_host_key, ts, metrics) {
   for (key in gauges) {
     zabbix = zabbix_host_key(key);
 
-    statString += zabbix.host + ' ' + zabbix.key + ' ' + ts + ' ' + gauges[key] + "\n";
+    Sender.addItem(zabbix.host, zabbix.key, gauges[key]);
     numStats += 1;
   }
 
-  post_stats(statString);
+  if (debug) {
+    util.log(Sender.items);
+  }
+
+  // now actually send the items to zabbix
+  Sender.send(function (err, res) {
+    if (debug && err) {
+      util.log('node-zabbix-sender send error: ' + err);
+    }
+
+    // print the response object - for testing
+    if (debug) {
+      util.log(res);
+    }
+  });
 };
 
 var backend_status = function zabbix_status(writeCb) {
@@ -231,14 +211,8 @@ exports.init = function zabbix_init(startup_time, config, events) {
   zabbixHost = config.zabbixHost;
   zabbixPort = config.zabbixPort;
   zabbixSender = config.zabbixSender;
+  zabbixTimestamps = config.timestamps;
   zabbix_host_key = config.hostname ? zabbix_host_key_from_config.bind(undefined, config.hostname) : zabbix_host_key_from_encoding;
-
-  if(zabbixSender) {
-    zabbixCmd = zabbixSender + ' -T -i - -z ' + zabbixHost + ' -p ' + zabbixPort;
-  }
-  else {
-    senderModule = require('node-zabbix-sender');
-  }
 
   zabbixStats.last_flush = startup_time;
   zabbixStats.last_exception = startup_time;

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -34,10 +34,6 @@ var zabbixStats = {};
 
 var post_stats = function zabbix_post_stats(statString) {
   if (zabbixHost) {
-    if (debug) {
-      util.log('statsString: ' + statString);
-    }
-
     if(zabbixCmd) {
       // we're spawning a child process to run the shell zabbix_sender command
       try {
@@ -64,12 +60,16 @@ var post_stats = function zabbix_post_stats(statString) {
         var statArray = statString.split('\n');
         statArray.forEach(function (v, i, array) {
           var data = v.split(' ', 4);
-          // third one is always the timestamp so leave that out.
-          Sender.addItem([data[0], data[1]].join('.'), data[3]);
-          if (debug) {
-            util.log([data[0], data[1]].join('.'), data[3]);
+          if (data[1]) {  // there might be a blank line at the end.
+            // third one is always the timestamp so leave that out.
+            Sender.addItem([data[0], data[1]].join('.'), data[3]);
+            if (debug) {
+              util.log([data[0], data[1]].join('.'), data[3]);
+            }
           }
         });
+
+
         Sender.send(function (err, res) {
           if (err) {
             throw err;
@@ -80,6 +80,9 @@ var post_stats = function zabbix_post_stats(statString) {
             util.log(res);
           }
         });
+
+
+
       } catch (e) {
         if (debug) {
           util.log('node-zabbix-sender error: ' + e);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "statsd-zabbix-backend",
+  "name": "@freecycle/statsd-zabbix-backend",
   "description": "A backend for StatsD to emit stats to Zabbix",
   "author": "Parker DeBardelaben",
   "repository": {
@@ -8,10 +8,13 @@
   },
   "version": "0.2.0",
   "engine": {
-    "node": ">=0.10"
+    "node": ">=8.x"
   },
   "main": "lib/zabbix.js",
-  "devDependencies" : {
+  "devDependencies": {
     "unit.js": "*"
+  },
+  "dependencies": {
+    "node-zabbix-sender": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@freecycle/statsd-zabbix-backend",
+  "name": "statsd-zabbix-backend",
   "description": "A backend for StatsD to emit stats to Zabbix",
   "author": "Parker DeBardelaben",
   "repository": {
     "type": "git",
     "url": "https://github.com/parkerd/statsd-zabbix-backend.git"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engine": {
-    "node": ">=8.x"
+    "node": ">=0.10"
   },
   "main": "lib/zabbix.js",
   "devDependencies": {


### PR DESCRIPTION
Adds the option of using the `node-zabbix-sender` module instead of a separate `zabbix-sender` binary.  If `zabbixSender` config variable is empty, will use the module.